### PR TITLE
Add missing parameter causing DataError on get_refund

### DIFF
--- a/swish/models.py
+++ b/swish/models.py
@@ -5,6 +5,7 @@ class Payment(models.Model):
     id = types.StringType()
     payee_payment_reference = types.StringType(serialized_name='payeePaymentReference')
     payment_reference = types.StringType(serialized_name='paymentReference')
+    callback_identifier = types.StringType(serialized_name='callbackIdentifier')
     callback_url = types.URLType(serialized_name='callbackUrl')
     payer_alias = types.StringType(serialized_name='payerAlias')
     payee_alias = types.StringType(serialized_name='payeeAlias')

--- a/swish/models.py
+++ b/swish/models.py
@@ -31,6 +31,7 @@ class Refund(models.Model):
     message = types.StringType()
     payer_alias = types.StringType(serialized_name='payerAlias')
     payee_alias = types.StringType(serialized_name='payeeAlias')
+    callback_identifier = types.StringType(serialized_name='callbackIdentifier')
     callback_url = types.URLType(serialized_name='callbackUrl')
     payer_payment_reference = types.StringType(serialized_name='payerPaymentReference')
     payment_reference = types.StringType(serialized_name='paymentReference')


### PR DESCRIPTION
Add missing parameter `callbackIdentifier` which is causing DataError on GET /refund/{id}

Sometime between May 19 and 20 swish api (in production) added `callbackIdentifier` to the response which is not present on the model.

```
site-packages/swish/client.py in get_refund(self, refund_id)
     79         response = self.get('refunds/' + refund_id)
     80         response.raise_for_status()
---> 81         return Refund(response.json())

site-packages/schematics/models.py in __init__(self, raw_data, trusted_data, deserialize_mapping, init, partial, strict, validate, app_data, lazy, **kwargs)
    233             trusted_data=trusted_data, mapping=deserialize_mapping,
    234             partial=partial, strict=strict, validate=validate, new=True,
--> 235             app_data=app_data, **kwargs)
    236         self._data.converted = data
    237         if validate:

site-packages/schematics/models.py in _convert(self, raw_data, context, **kwargs)
    297         should_validate = getattr(context, 'validate', kwargs.get('validate', False))
    298         func = validate if should_validate else convert
--> 299         return func(self._schema, self, raw_data=raw_data, oo=True, context=context, **kwargs)
    300
    301     def export(self, field_converter=None, role=None, app_data=None, **kwargs):

site-packages/schematics/transforms.py in convert(cls, mutable, raw_data, **kwargs)
    426
    427 def convert(cls, mutable, raw_data=None, **kwargs):
--> 428     return import_loop(cls, mutable, raw_data, import_converter, **kwargs)
    429
    430

site-packages/schematics/transforms.py in import_loop(schema, mutable, raw_data, field_converter, trusted_data, mapping, partial, strict, init_values, apply_defaults, convert, validate, new, oo, recursive, app_data, context)
    172
    173     if errors:
--> 174         raise DataError(errors, data)
    175
    176     data = context.field_converter.post(schema, data, context)

DataError: {"callbackIdentifier": "Rogue field"}
```